### PR TITLE
Add no-tree-vectorize attribute to functions

### DIFF
--- a/advance/blit/imean.h
+++ b/advance/blit/imean.h
@@ -131,6 +131,7 @@ static inline void internal_mean32_vert_self_mmx(uint32* dst, const uint32* src,
 }
 #endif
 
+__attribute__((optimize("no-tree-vectorize")))
 static inline void internal_mean32_vert_self_def(uint32* dst32, const uint32* src32, unsigned count)
 {
 	while (count) {

--- a/advance/blit/vfilter.h
+++ b/advance/blit/vfilter.h
@@ -43,6 +43,7 @@ static void video_line_filter8_step1_mmx(const struct video_stage_horz_struct* s
 }
 #endif
 
+__attribute__((optimize("no-tree-vectorize")))
 static void video_line_filter8_step1_def(const struct video_stage_horz_struct* stage, unsigned line, void* dst, const void* src, unsigned count)
 {
 	internal_mean8_horz_next_step1_def(dst, src, count);
@@ -69,6 +70,7 @@ static void video_line_filter16_step2_mmx(const struct video_stage_horz_struct* 
 }
 #endif
 
+__attribute__((optimize("no-tree-vectorize")))
 static void video_line_filter16_step2_def(const struct video_stage_horz_struct* stage, unsigned line, void* dst, const void* src, unsigned count)
 {
 	internal_mean16_horz_next_step2_def(dst, src, count);
@@ -95,6 +97,7 @@ static void video_line_filter32_step4_mmx(const struct video_stage_horz_struct* 
 }
 #endif
 
+__attribute__((optimize("no-tree-vectorize")))
 static void video_line_filter32_step4_def(const struct video_stage_horz_struct* stage, unsigned line, void* dst, const void* src, unsigned count)
 {
 	internal_mean32_horz_next_step4_def(dst, src, count);


### PR DESCRIPTION
Tree auto-vectorization is currently broken in gcc (6.2) for these functions, and triggers an Internal Compiler Error in DJGPP when -ftree-vectorize is enabled (incl. using -O3).  Attributing these specific function allows the build to continue.