### PR TITLE
Added support for Donkey Kong Pauline Edition hack of US set 1

### DIFF
--- a/src/drivers/dkong.c
+++ b/src/drivers/dkong.c
@@ -2002,6 +2002,41 @@ I use more appropreate filenames for color PROMs.
     ROM_LOAD( "dkong.5f",     0x0200, 0x0100, CRC(44988665) )
 *********************************************************/
 ROM_END
+ROM_START( dkongpe )
+	ROM_REGION( 0x10000, REGION_CPU1, 0 )	/* 64k for code */
+	ROM_LOAD( "c_5et_g.bin",  0x0000, 0x1000, CRC(ba70b88b) SHA1(d76ebecfea1af098d843ee7e578e480cd658ac1a) )
+	ROM_LOAD( "c_5ct_g.bin",  0x1000, 0x1000, CRC(45af403e) SHA1(6030a4af7df98bfdf5b35a9a42541566f7d12901) )
+	ROM_LOAD( "c_5bt_g.bin",  0x2000, 0x1000, CRC(3a9783b7) SHA1(e98d757c048f2180ba22c774e0e425ddc661ba8c) )
+	ROM_LOAD( "c_5at_g.bin",  0x3000, 0x1000, CRC(32bc20ff) SHA1(ef141f437912923625722b83a33ea182eaa31427) )
+	/* space for diagnostic ROM */
+
+	ROM_REGION( 0x1000, REGION_CPU2, 0 )	/* sound */
+	ROM_LOAD( "s_3i_b.bin",   0x0000, 0x0800, CRC(45a4ed06) SHA1(144d24464c1f9f01894eb12f846952290e6e32ef) )
+	ROM_LOAD( "s_3j_b.bin",   0x0800, 0x0800, CRC(4743fe92) SHA1(6c82b57637c0212a580591397e6a5a1718f19fd2) )
+
+	ROM_REGION( 0x1000, REGION_GFX1, ROMREGION_DISPOSE )
+	ROM_LOAD( "v_5h_b.bin",   0x0000, 0x0800, CRC(007aa348) SHA1(ff2ae583fef6da9d260fda8f4a896dd0414c3388) )
+	ROM_LOAD( "v_3pt.bin",    0x0800, 0x0800, CRC(a967aff0) SHA1(7bcfdbeb0a5cdfec604eb8450664bc4b789526be) )
+
+	ROM_REGION( 0x2000, REGION_GFX2, ROMREGION_DISPOSE )
+	ROM_LOAD( "l_4m_b.bin",   0x0000, 0x0800, CRC(766ae006) SHA1(0ec53798aa2c30b2c5c8b2f99b811a187faa2549) )
+	ROM_LOAD( "l_4n_b.bin",   0x0800, 0x0800, CRC(39e7ca4b) SHA1(b77ddd39608d08013fa8bb764c8e5aa4e03181dc) )
+	ROM_LOAD( "l_4r_b.bin",   0x1000, 0x0800, CRC(012f2f25) SHA1(836709192a249b00ded783be542ee844eb930c7a) )
+	ROM_LOAD( "l_4s_b.bin",   0x1800, 0x0800, CRC(84eb5bfb) SHA1(c1f38efb8670f1a489275eb8ff576a95d140cfb9) )
+
+	ROM_REGION( 0x0300, REGION_PROMS, 0 )
+	ROM_LOAD( "c-2k.bpr",     0x0000, 0x0100, CRC(e273ede5) SHA1(b50ec9e1837c00c20fb2a4369ec7dd0358321127) ) /* palette low 4 bits (inverted) */
+	ROM_LOAD( "c-2j.bpr",     0x0100, 0x0100, CRC(d6412358) SHA1(f9c872da2fe8e800574ae3bf483fb3ccacc92eb3) ) /* palette high 4 bits (inverted) */
+	ROM_LOAD( "v-5e.bpr",     0x0200, 0x0100, CRC(b869b8f5) SHA1(c2bdccbf2654b64ea55cd589fd21323a9178a660) ) /* character color codes on a per-column basis */
+
+/*********************************************************
+I use more appropreate filenames for color PROMs.
+    ROM_REGION( 0x0300, REGION_PROMS, 0 )
+    ROM_LOAD( "dkong.2k",     0x0000, 0x0100, CRC(1e82d375) )
+    ROM_LOAD( "dkong.2j",     0x0100, 0x0100, CRC(2ab01dc8) )
+    ROM_LOAD( "dkong.5f",     0x0200, 0x0100, CRC(44988665) )
+*********************************************************/
+ROM_END
 
 ROM_START( dkongo )
 	ROM_REGION( 0x10000, REGION_CPU1, 0 )	/* 64k for code */
@@ -2862,6 +2897,7 @@ GAME( 1980, radarscp, 0,        radarscp, dkong,    radarscp, ROT90, "Nintendo",
 
 GAME( 1981, dkong,    0,        dkong,    dkong,    0,        ROT90, "Nintendo of America", "Donkey Kong (US set 1)", GAME_SUPPORTS_SAVE )
 GAME( 1981, dkongo,   dkong,    dkong,    dkong,    0,        ROT90, "Nintendo", "Donkey Kong (US set 2)", GAME_SUPPORTS_SAVE )
+GAME( 1981, dkongpe,  dkong,    dkong,    dkong,    0,        ROT90, "Nintendo of America", "Donkey Kong Pauline Edition (Clay Cowgill bootleg of US set 1)", GAME_SUPPORTS_SAVE )
 GAME( 1981, dkongjp,  dkong,    dkong,    dkong,    0,        ROT90, "Nintendo", "Donkey Kong (Japan set 1)", GAME_SUPPORTS_SAVE )
 GAME( 1981, dkongjo,  dkong,    dkong,    dkong,    0,        ROT90, "Nintendo", "Donkey Kong (Japan set 2)", GAME_SUPPORTS_SAVE )
 GAME( 1981, dkongjo1, dkong,    dkong,    dkong,    0,        ROT90, "Nintendo", "Donkey Kong (Japan set 3) (bad dump?)", GAME_SUPPORTS_SAVE )

--- a/src/mamedriv.c
+++ b/src/mamedriv.c
@@ -888,6 +888,7 @@ const game_driver * const drivers[] =
 	DRIVER( radarscp )	/* (c) 1980 Nintendo */
 	DRIVER( dkong )		/* (c) 1981 Nintendo of America */
 	DRIVER( dkongo )	/* (c) 1981 Nintendo */
+	DRIVER( dkongpe )	/* (c) 1981,2013 Nintendo */
 	DRIVER( dkongjp )	/* (c) 1981 Nintendo */
 	DRIVER( dkongjo )	/* (c) 1981 Nintendo */
 	DRIVER( dkongjo1 )	/* (c) 1981 Nintendo */


### PR DESCRIPTION
The Donkey Kong Pauline Edition (created by Clay Cowgill, with a nice writeup at http://www.multigame.com/dkp_arcade.html) plays just fine in advmame but brings up a bunch of CRC warnings in the MAME startup. This little patch handles that by creating a new driver `dkongpe` with the correct checksums.

He doesn't distribute roms (only a patchset) in order not to run afoul of big N, but I'm attaching a patched copy here for your testing if you were interested in including this.

[dkongpe.zip](https://github.com/amadvance/advancemame/files/1884967/dkongpe.zip)

