### PR TITLE
New Working Game Snow Board Championship

### DIFF
--- a/src/drivers/gaelco2.c
+++ b/src/drivers/gaelco2.c
@@ -25,6 +25,7 @@
 extern UINT16 *gaelco_sndregs;
 extern UINT16 *gaelco2_vregs;
 extern UINT16 *snowboar_protection;
+extern UINT32  snowboard_latch;
 
 /* comment this line to display 2 monitors for the dual monitor games */
 //#define ONE_MONITOR
@@ -1383,7 +1384,7 @@ GAME( 1995, touchgon, touchgo,  touchgo,  touchgo,  touchgo,  ROT0, "Gaelco", "T
 GAME( 1995, touchgoe, touchgo,  touchgo,  touchgo,  touchgo,  ROT0, "Gaelco", "Touch & Go (earlier revision)", GAME_UNEMULATED_PROTECTION | GAME_NOT_WORKING )
 GAME( 1995, wrally2,  0,        wrally2,  wrally2,  0,        ROT0, "Gaelco", "World Rally 2: Twin Racing", GAME_UNEMULATED_PROTECTION )
 GAME( 1996, maniacsq, 0,        maniacsq, maniacsq, 0,        ROT0, "Gaelco", "Maniac Square (unprotected)", 0 )
-GAME( 1996, snowboar, 0,        snowboar, snowboar, snowboar, ROT0, "Gaelco", "Snow Board Championship (set 1)", GAME_UNEMULATED_PROTECTION )
-GAME( 1996, snowbalt, snowboar, snowboar, snowboar, 0,        ROT0, "Gaelco", "Snow Board Championship (set 2)", GAME_UNEMULATED_PROTECTION )
+GAME( 1996, snowboar, 0,        snowboar, snowboar, snowboar, ROT0, "Gaelco", "Snow Board Championship (set 1)", 0 )
+GAME( 1996, snowbalt, snowboar, snowboar, snowboar, 0,        ROT0, "Gaelco", "Snow Board Championship (set 2)", 0 )
 GAME( 1998, bang,     0,        bang,     bang,     bang,     ROT0, "Gaelco", "Bang!", 0 )
 GAME( 1998, bangj,    bang,     bang,     bang,     bang,     ROT0, "Gaelco", "Gun Gabacho (Japan)", 0 )


### PR DESCRIPTION
0.171: Samuel Neves and Peter Wilhelmsen figured out algorithm and replaced Snow Board Championship lookup table with proper emulation of device.
0.170: Charles MacDonald and David Haywood added 8GB decrypt table to Snow Board Championship and clone - Game now playable.