### PR TITLE
Fix some minor issues in advancemame compilation.

### DIFF
--- a/advance/dos/wss.c
+++ b/advance/dos/wss.c
@@ -5323,7 +5323,7 @@ DWORD w_get_actual_sample_rate(void)
 			d1 = 65536;
 			get_played_sample_count();
 			while (d1 > 0) {
-				if (get_played_sample_count != 0) break;
+				if (get_played_sample_count() != 0) break;
 				d1 -= 1;
 			}
 			prev = osd_cycles();

--- a/advance/svgalib/svgalib.c
+++ b/advance/svgalib/svgalib.c
@@ -1628,7 +1628,7 @@ void ADV_SVGALIB_CALL adv_svgalib_save(unsigned char* regs)
 {
 	adv_svgalib_log("svgalib: adv_svgalib_save()\n");
 
-	memset(regs, ADV_SVGALIB_STATE_SIZE, 0);
+	memset(regs, 0, ADV_SVGALIB_STATE_SIZE);
 
 	if (adv_svgalib_state.driver->drv->unlock)
 		adv_svgalib_state.driver->drv->unlock();

--- a/src/machine/eeprom.c
+++ b/src/machine/eeprom.c
@@ -245,8 +245,8 @@ logerror("EEPROM unlock\n");
 
 static void EEPROM_reset(void)
 {
-if (serial_count)
-	logerror("EEPROM reset, buffer = %s\n",serial_buffer);
+	if (serial_count)
+logerror("EEPROM reset, buffer = %s\n",serial_buffer);
 
 	serial_count = 0;
 	sending = 0;


### PR DESCRIPTION
* `advance/dos/wss.c`: `get_played_sample_count()` was missing parentheses, causing the function address to be compared instead of the return value.
* `advance/svgalib/svgalib.c`: `memset` argument order was incorrect, causing the structure to be uninitialized instead
* `src/machine/eeprom.c`: indent order of debug print triggered a spurious warning about "if" guarding