### PR TITLE
Small graphical hack for Lethal Enforcers

### DIFF
--- a/src/vidhrdw/konamiic.c
+++ b/src/vidhrdw/konamiic.c
@@ -6764,6 +6764,11 @@ void K056832_tilemap_draw(mame_bitmap *bitmap, const rectangle *cliprect, int la
 
 			sdat_offs = sdat_walk & sdat_wrapmask;
 
+			if(strcmp(Machine->gamedrv->name, "lethalen") == 0)
+			{
+                           if (scrollmode==2) sdat_offs = sdat_offs + 0x1e0 + 14;
+	                }
+
 			drawrect.min_y = (dminy < cminy ) ? cminy : dminy;
 			drawrect.max_y = (dmaxy > cmaxy ) ? cmaxy : dmaxy;
 


### PR DESCRIPTION
0.143u7: Roberto Zandona fixed Lethal Enforcers external rowscroll not hooked up correctly (1st attract level, highscores) and some priority issues / sprite placement issues.