### PR TITLE
Small gfx fix for Taito's Super Ground Effects

### DIFF
--- a/src/vidhrdw/groundfx.c
+++ b/src/vidhrdw/groundfx.c
@@ -247,7 +247,7 @@ VIDEO_UPDATE( groundfx )
 	fillbitmap(priority_bitmap,0,cliprect);
 	fillbitmap(bitmap,Machine->pens[0],cliprect);	/* wrong color? */
 
-	TC0100SCN_tilemap_draw(bitmap,cliprect,0,pivlayer[0],0,0);
+	TC0100SCN_tilemap_draw(bitmap,cliprect,0,pivlayer[0],TILEMAP_IGNORE_TRANSPARENCY,0);
 	TC0100SCN_tilemap_draw(bitmap,cliprect,0,pivlayer[1],0,0);
 
 	/*  BIG HACK!


### PR DESCRIPTION
0.125u2: Phil Bennett fixed black pixel patches present in the TC0100SCN fg layer of Ground Effects.