### PR TITLE
Improve emulation for Double Wings

### DIFF
--- a/src/drivers/dblewing.c
+++ b/src/drivers/dblewing.c
@@ -1,52 +1,71 @@
-/* Double Wing */
-
 /*
-
-the most protected of the DE102 games?
-
--- you can't select your plane
--- locks up at boss
-
+Double Wings
+Mitchell 1993
+This game runs on Data East hardware.
+PCB Layout
+----------
+S-NK-3220
+DEC-22VO
+|---------------------------------------------|
+|MB3730 C3403    32.22MHz           MBE-01.16A|
+|  Y3014B  KP_03-.16H       77                |
+|           M6295                   MBE-00.14A|
+|  YM2151                            |------| |
+|          Z80      CXK5864          |      | |
+| VOL                       VG-02.11B|  52  | |
+|        LH5168     CXK5864          |      | |
+|                                    |------| |
+|                  |------|              28MHz|
+|J       KP_02-.10H|      |                   |
+|A                 | 141  |         CXK5814   |
+|M       MBE-02.8H |      |                   |
+|M                 |      |         CXK5814   |
+|A                 |------|                   |
+|                                   CXK5814   |
+|                 KP_01-.5D                   |
+|                                   CXK5814   |
+|                 CXK5864                     |
+| |----|          KP_00-.3D         |------|  |
+| |104 |                            | 102  |  |
+| |    |          CXK5864           |      |  |
+| |----|                            |      |  |
+|SW2 SW1 VG-01.1H VG-00.1F          |------|  |
+|---------------------------------------------|
+Notes:
+       102     - Custom encrypted 68000 CPU. Clock 14.000MHz [28/2]
+       Z80     - Toshiba TMPZ84C000AP-6 Z80 CPU. Clock 3.58MHz [32.22/9]
+       YM2151  - Yamaha YM2151 FM Operator Type-M (OPM) sound chip. Clock 3.58MHz [32.22/9]
+       M6295   - Oki M6295 4-channel mixing ADPCM LSI. Clock 1.000MHz [28/28]. Pin 7 HIGH
+       LH6168  - Sharp LH6168 8kx8 SRAM (DIP28)
+       CXK5814 - Sony CXK5816 2kx8 SRAM (DIP24)
+       CXK5864 - Sony CXK5864 8kx8 SRAM (DIP28)
+       VG-*    - MMI PAL16L8 (DIP20)
+       SW1/SW2 - 8-position DIP switch
+       HSync   - 15.6250kHz
+       VSync   - 58.4443Hz
+       Other DATA EAST Chips
+       --------------------------------------
+       DATA EAST 52  9235EV 205941 VC5259-0001 JAPAN   (Sprite Generator IC, 128 pin PQFP)
+       DATA EAST 102 (M) DATA EAST 250 JAPAN           (Encrypted 68000 CPU, 128 Pin PQFP)
+       DATA EAST 141 24220F008                         (Tile Generator IC, 160 pin PQFP)
+       DATA EAST 104 L7A0717 9143 (M) DATA EAST        (IO/Protection, 100 pin PQFP)
+       Small surface-mounted chip with number scratched off (28 pin SOP), but has number 9303K9200
+       A similar chip exists on Capt. America PCB and has the number 77 on it. Possibly the same chip?
+	   
+ - Main program writes two commands to soundlatch without pause in some places. Should the 104 custom
+   chip be handling this through an internal FIFO?
+ - should sprites be buffered, is the Deco '77' a '71' or similar?
 */
-
 #include "driver.h"
 #include "cpu/m68000/m68000.h"
+#include "cpu/z80/z80.h"
 #include "decocrpt.h"
 #include "deco16ic.h"
 #include "sound/2151intf.h"
 #include "sound/okim6295.h"
 
-extern void deco102_decrypt(int region, int address_xor, int data_select_xor, int opcode_select_xor);
 
-/*
-
-offs +0
--------- --------
- fFbSssy yyyyyyyy
-
-s = size (multipart)
-S = size (x?) (does any other game use this?)
-f = flipy
-b = flash
-F = flipx
-y = ypos
-
-offs +1
--------- --------
-tttttttt tttttttt
-
-t = sprite tile
-
-offs +2
--------- --------
-ppcccccx xxxxxxxx
-
-c = colour palette
-p = priority
-x = xpos
-
-*/
-
+static UINT8 dblewing_sound_irq;
 
 
 static void dblewing_drawsprites(mame_bitmap *bitmap,const rectangle *cliprect)
@@ -237,38 +256,68 @@ static UINT16 dblwings_580_data;
 static UINT16 dblwings_60a_data;
 static UINT16 dblwings_200_data;
 static UINT16 dblwings_28c_data;
+static UINT16 dblwings_18a_data;
+static UINT16 dblwings_280_data;
+static UINT16 dblwings_384_data;
 
+static UINT16 boss_move,boss_shoot_type,boss_3_data,boss_4_data,boss_5_data,boss_5sx_data,boss_6_data;
 
-READ16_HANDLER ( dlbewing_prot_r )
+static READ16_HANDLER ( dblewing_prot_r )
 {
-	if ((offset*2)==0x068) return 0;//dblwings_78a_data;
-	if ((offset*2)==0x094) return dblwings_104_data; // p1 inputs select screen  OK
-	if ((offset*2)==0x0f8) return 0;// dblwings_080_data;
+	switch(offset*2)
+	{
+		case 0x16a: return boss_move;          // boss 1 movement
+		case 0x6d6: return boss_move;          // boss 1 2nd pilot
+		case 0x748: return boss_move;          // boss 1 3rd pilot
+
+		case 0x566: return 0x0009;   	   	   // boss BGM,might be a variable one (read->write to the sound latch)
+		case 0x1ea: return boss_shoot_type;    // boss 1 shoot type
+		case 0x596: return boss_3_data;		   // boss 3 appearing
+		case 0x692:	return boss_4_data;
+		case 0x6b0: return boss_5_data;
+		case 0x51e: return boss_5sx_data;
+		case 0x784: return boss_6_data;
+
+		case 0x330: return 0; // controls bonuses such as shoot type,bombs etc.
+		case 0x1d4: return dblwings_70c_data;  //controls restart points
+
+		case 0x0ac: return (readinputportbytag("DSW") & 0x40)<<4;//flip screen
+		case 0x4b0: return dblwings_608_data;//coinage
+		case 0x068:
+		{
+			switch(readinputportbytag("DSW") & 0x0300) //I don't know how to relationate this...
+			{
+				case 0x0000: return 0x000;//0
+				case 0x0100: return 0x060;//3
+				case 0x0200: return 0x0d0;//6
+				case 0x0300: return 0x160;//b
+			}
+		}
+		case 0x094: return dblwings_104_data;// p1 inputs select screen  OK
+		case 0x24c: return dblwings_008_data;//read DSW (mirror for coinage/territory)
+		case 0x298: return readinputportbytag("SYSTEM");//vblank
+		case 0x476: return readinputportbytag("SYSTEM");//mirror for coins
+		case 0x506: return readinputportbytag("DSW");
+		case 0x5d8: return dblwings_406_data;
+		case 0x2b4: return readinputportbytag("P1_P2");
+		case 0x1a8: return (readinputportbytag("DSW") & 0x4000) >> 12;//allow continue
+		case 0x3ec: return dblwings_70c_data; //score entry
+		case 0x246: return dblwings_580_data; // these three controls "perfect bonus" I suppose...
+		case 0x52e: return dblwings_580_data;
+		case 0x532: return dblwings_580_data;
+	}
+
+
+//  printf("dblewing prot r %08x, %04x, %04x\n",cpu_get_pc(space->cpu), offset*2, mem_mask);
+
+	if ((offset*2)==0x0f8) return 0; // dblwings_080_data;
 	if ((offset*2)==0x104) return 0;
 	if ((offset*2)==0x10e) return 0;
-	if ((offset*2)==0x16a) return 0;
-	if ((offset*2)==0x1a8) return 0;
-	if ((offset*2)==0x1d4) return 0;
-	if ((offset*2)==0x1ea) return 0;
-	if ((offset*2)==0x206) return 0;//dblwings_70c_data;
-	if ((offset*2)==0x24c) return 0;//dblwings_78a_data;
-	if ((offset*2)==0x246) return 0; // end of leve
+	if ((offset*2)==0x206) return 0; // dblwings_70c_data;
 	if ((offset*2)==0x25c) return 0;
-	if ((offset*2)==0x284) return 0; //3rd player 2nd boss
-	if ((offset*2)==0x330) return 0; // sound?
-	if ((offset*2)==0x3ec) return 0; // sound?
+	if ((offset*2)==0x284) return 0; // 3rd player 2nd boss
 	if ((offset*2)==0x432) return 0; // boss on water level?
-	if ((offset*2)==0x476) return dblwings_008_data; // dips?
-	if ((offset*2)==0x4b0) return dblwings_608_data;
-	if ((offset*2)==0x52e) return 0; // end of leve
-	if ((offset*2)==0x532) return 0; // end of leve
-	if ((offset*2)==0x54a) return 0; //3rd player 2nd boss
-	if ((offset*2)==0x566) return 0; // bosses?
-	if ((offset*2)==0x596) return 0;
-	if ((offset*2)==0x5d8) return dblwings_406_data; // p2 inputs select screen  OK
-	if ((offset*2)==0x692) return 0; // boss on water level?
-	if ((offset*2)==0x6d6) return 0;
-	if ((offset*2)==0x748) return 0;//dblwings_408_data; // dblwings_408_data // 3rd player 1st level?
+	if ((offset*2)==0x54a) return 0; // 3rd player 2nd boss
 	if ((offset*2)==0x786) return 0;
 
 	printf("dblewing prot r %08x, %04x, %04x\n",activecpu_get_pc(), offset*2, mem_mask);
@@ -276,50 +325,134 @@ READ16_HANDLER ( dlbewing_prot_r )
 	return 0;//mame_rand();
 }
 
-WRITE16_HANDLER( dblewing_prot_w )
+static WRITE16_HANDLER( dblewing_prot_w )
 {
+//  if(offset*2 != 0x380)
+//  printf("dblewing prot w %08x, %04x, %04x %04x\n",cpu_get_pc(space->cpu), offset*2, mem_mask,data);
+
+	switch(offset*2)
+	{
+		case 0x088:
+			dblwings_088_data = data;
+			if(dblwings_088_data == 0)          { boss_4_data = 0;    }
+			else if(dblwings_088_data & 0x8000) { boss_4_data = 0x50; }
+			else                                { boss_4_data = 0x40; }
+
+			return;
+
+		case 0x104:
+			dblwings_104_data = data;
+			return; // p1 inputs select screen  OK
+
+		case 0x18a:
+			dblwings_18a_data = data;
+			switch(dblwings_18a_data)
+			{
+				case 0x6b94: boss_5_data = 0x10; break; //initialize
+				case 0x7c68: boss_5_data = 0x60; break; //go up
+				case 0xfb1d: boss_5_data = 0x50; break;
+				case 0x977c: boss_5_data = 0x50; break;
+				case 0x8a49: boss_5_data = 0x60; break;
+			}
+			return;
+		case 0x200:
+			dblwings_200_data = data;
+			switch(dblwings_200_data)
+			{
+				case 0x5a19: boss_move = 1; break;
+				case 0x3b28: boss_move = 2; break;
+				case 0x1d4d: boss_move = 1; break;
+			}
+			//popmessage("%04x",dblwings_200_data);
+			return;
+		case 0x280:
+			dblwings_280_data = data;
+			switch(dblwings_280_data)
+			{
+				case 0x6b94: boss_5sx_data = 0x10; break;
+				case 0x7519: boss_5sx_data = 0x60; break;
+				case 0xfc68: boss_5sx_data = 0x50; break;
+				case 0x02dd: boss_5sx_data = 0x50; break;
+				case 0x613c: boss_5sx_data = 0x50; break;
+			}
+			//printf("%04x\n",dblwings_280_data);
+			return;
+		case 0x380: // sound write
+			soundlatch_w(0,data&0xff);
+			dblewing_sound_irq |= 0x02;
+		 	cpunum_set_input_line(1,0,(dblewing_sound_irq != 0) ? ASSERT_LINE : CLEAR_LINE);
+			return;
+		case 0x384:
+			dblwings_384_data = data;
+			switch(dblwings_384_data)
+			{
+				case 0xaa41: boss_6_data = 1; break;
+				case 0x5a97: boss_6_data = 2; break;
+				case 0xbac5: boss_6_data = 3; break;
+				case 0x0afb: boss_6_data = 4; break;
+				case 0x6a99: boss_6_data = 5; break;
+				case 0xda8f: boss_6_data = 6; break;
+			}
+			return;
+		case 0x38e:
+			dblwings_38e_data = data;
+			switch(dblwings_38e_data)
+			{
+				case 0x6c13: boss_shoot_type = 3; break;
+				case 0xc311: boss_shoot_type = 0; break;
+				case 0x1593: boss_shoot_type = 1; break;
+				case 0xf9db: boss_shoot_type = 2; break;
+				case 0xf742: boss_shoot_type = 3; break;
+
+				case 0xeff5: boss_move = 1; break;
+				case 0xd2f1: boss_move = 2; break;
+				//default:   printf("%04x\n",dblwings_38e_data); break;
+				//case 0xe65a: boss_shoot_type = 0; break;
+			}
+			return;
+		case 0x58c: // 3rd player 1st level
+			dblwings_58c_data = data;
+			if(dblwings_58c_data == 0)     { boss_move = 5; }
+			else                           { boss_move = 2; }
+
+			return;
+		case 0x60a:
+			dblwings_60a_data = data;
+			if(dblwings_60a_data & 0x8000) { boss_3_data = 2; }
+			else                           { boss_3_data = 9; }
+
+			return;
+		case 0x580:
+			dblwings_580_data = data;
+			return;
+		case 0x406:
+			dblwings_406_data = data;
+			return;  // p2 inputs select screen  OK
+	}
+
+//  printf("dblewing prot w %08x, %04x, %04x %04x\n",cpu_get_pc(space->cpu), offset*2, mem_mask,data);
+
 	if ((offset*2)==0x008) { dblwings_008_data = data; return; }
-	if ((offset*2)==0x088) { dblwings_088_data = data; return; }
 	if ((offset*2)==0x080) { dblwings_080_data = data; return; } // p3 3rd boss?
-	if ((offset*2)==0x104) { dblwings_104_data = data; return; } // p1 inputs select screen  OK
-	if ((offset*2)==0x200) { dblwings_200_data = data; return; }
 	if ((offset*2)==0x28c) { dblwings_28c_data = data; return; }
-	if ((offset*2)==0x380) { soundlatch_w(0,data&0xff);	/*cpunum_set_input_line(1,0,HOLD_LINE);*/ return; } // sound write
-	if ((offset*2)==0x38e) { dblwings_38e_data = data; return; }
-	if ((offset*2)==0x406) { dblwings_406_data = data; return; } // p2 inputs select screen  OK
 	if ((offset*2)==0x408) { dblwings_408_data = data; return; } // 3rd player 1st level?
 	if ((offset*2)==0x40e) { dblwings_40e_data = data; return; } // 3rd player 2nd level?
-	if ((offset*2)==0x580) { dblwings_580_data = data; return; }
-	if ((offset*2)==0x58c) { dblwings_58c_data = data; return; } // 3rd player 1st level?
 	if ((offset*2)==0x608) { dblwings_608_data = data; return; }
-	if ((offset*2)==0x60a) { dblwings_60a_data = data; return; }
 	if ((offset*2)==0x70c) { dblwings_70c_data = data; return; }
 	if ((offset*2)==0x78a) { dblwings_78a_data = data; return; }
 	if ((offset*2)==0x788) { dblwings_788_data = data; return; }
-
-	printf("dblewing prot w %08x, %04x, %04x %04x\n",activecpu_get_pc(), offset*2, mem_mask,data);
 }
+
+
+
 
 static ADDRESS_MAP_START( dblewing_map, ADDRESS_SPACE_PROGRAM, 16 )
 	AM_RANGE(0x000000, 0x07ffff) AM_ROM
-
 	AM_RANGE(0x100000, 0x100fff) AM_READ(MRA16_RAM) AM_WRITE(deco16_pf1_data_w) AM_BASE(&deco16_pf1_data)
 	AM_RANGE(0x102000, 0x102fff) AM_READ(MRA16_RAM) AM_WRITE(deco16_pf2_data_w) AM_BASE(&deco16_pf2_data)
 	AM_RANGE(0x104000, 0x104fff) AM_READ(MRA16_RAM) AM_WRITE(MWA16_RAM) AM_BASE(&deco16_pf1_rowscroll)
 	AM_RANGE(0x106000, 0x106fff) AM_READ(MRA16_RAM) AM_WRITE(MWA16_RAM) AM_BASE(&deco16_pf2_rowscroll)
-
-	/* protection */
-//  AM_RANGE(0x280104, 0x280105) AM_WRITE(MWA16_NOP) // ??
-	AM_RANGE(0x2800ac, 0x2800ad) AM_READ(input_port_2_word_r) // dips
-	AM_RANGE(0x280298, 0x280299) AM_READ(input_port_1_word_r) // vbl
-	AM_RANGE(0x280506, 0x280507) AM_READ(input_port_3_word_r)
-	AM_RANGE(0x2802B4, 0x2802B5) AM_READ(input_port_0_word_r) // inverted?
-//  AM_RANGE(0x280330, 0x280331) AM_READ(MRA16_NOP) // sound?
-//  AM_RANGE(0x280380, 0x280381) AM_WRITE(MWA16_NOP) // sound
-
-	AM_RANGE(0x280000, 0x2807ff) AM_READWRITE(dlbewing_prot_r,dblewing_prot_w)
-
-
+	AM_RANGE(0x280000, 0x2807ff) AM_READWRITE(dblewing_prot_r,dblewing_prot_w)
 	AM_RANGE(0x284000, 0x284001) AM_RAM
 	AM_RANGE(0x288000, 0x288001) AM_RAM
 	AM_RANGE(0x28C000, 0x28C00f) AM_WRITE(MWA16_RAM) AM_BASE(&deco16_pf12_control)
@@ -329,28 +462,28 @@ static ADDRESS_MAP_START( dblewing_map, ADDRESS_SPACE_PROGRAM, 16 )
 ADDRESS_MAP_END
 
 
-static WRITE8_HANDLER( YM2151_w )
+static READ8_HANDLER(irq_latch_r)
 {
-	switch (offset) {
-	case 0:
-		YM2151_register_port_0_w(0,data);
-		break;
-	case 1:
-		YM2151_data_port_0_w(0,data);
-		break;
-	}
+	/* bit 1 of dblewing_sound_irq specifies IRQ command writes */
+	dblewing_sound_irq &= ~0x02;
+	cpunum_set_input_line(1,0, (dblewing_sound_irq != 0) ? ASSERT_LINE : CLEAR_LINE);
+	return dblewing_sound_irq;
 }
 
 
 static ADDRESS_MAP_START( sound_map, ADDRESS_SPACE_PROGRAM, 8 )
 	AM_RANGE(0x0000, 0x7fff) AM_ROM
 	AM_RANGE(0x8000, 0x87ff) AM_RAM
-//  AM_RANGE(0xa000, 0xa001) AM_READWRITE(YM2151_status_port_0_r,YM2151_w)
-//  AM_RANGE(0xb000, 0xb000) AM_READ(OKIM6295_status_0_r)
-//  AM_RANGE(0xd000, 0xd000) AM_READ(soundlatch_r)
+ 	AM_RANGE(0xa000, 0xa001) AM_READWRITE(YM2151_status_port_0_r,YM2151_word_0_w)
+	AM_RANGE(0xb000, 0xb000) AM_READWRITE(OKIM6295_status_0_r, OKIM6295_data_0_w)
+	AM_RANGE(0xc000, 0xc000) AM_READ(soundlatch_r)
+ 	AM_RANGE(0xd000, 0xd000) AM_READ(irq_latch_r) //timing? sound latch?
+ 	AM_RANGE(0xf000, 0xf000) AM_READWRITE(OKIM6295_status_0_r, OKIM6295_data_0_w)
 ADDRESS_MAP_END
 
-
+static ADDRESS_MAP_START( dblewing_io_sound, ADDRESS_SPACE_IO, 8 )
+	AM_RANGE(0x0000, 0xffff) AM_ROM AM_REGION(REGION_SOUND2, 0)
+ADDRESS_MAP_END
 
 static const gfx_layout tile_8x8_layout =
 {
@@ -396,7 +529,7 @@ static const gfx_decode gfxdecodeinfo[] =
 };
 
 INPUT_PORTS_START( dblewing )
-	PORT_START	/* 16bit */
+	PORT_START_TAG("P1_P2")
 	PORT_BIT( 0x0001, IP_ACTIVE_LOW, IPT_JOYSTICK_UP ) PORT_8WAY PORT_PLAYER(1)
 	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_JOYSTICK_DOWN ) PORT_8WAY PORT_PLAYER(1)
 	PORT_BIT( 0x0004, IP_ACTIVE_LOW, IPT_JOYSTICK_LEFT ) PORT_8WAY PORT_PLAYER(1)
@@ -414,63 +547,61 @@ INPUT_PORTS_START( dblewing )
 	PORT_BIT( 0x4000, IP_ACTIVE_LOW, IPT_BUTTON3 ) PORT_PLAYER(2)
 	PORT_BIT( 0x8000, IP_ACTIVE_LOW, IPT_START2 )
 
-	PORT_START	/* 16bit */
+	PORT_START_TAG("SYSTEM")
 	PORT_BIT( 0x0001, IP_ACTIVE_LOW, IPT_COIN1 )
 	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_COIN2 )
 	PORT_BIT( 0x0004, IP_ACTIVE_LOW, IPT_SERVICE1 )
 	PORT_BIT( 0x0008, IP_ACTIVE_HIGH, IPT_VBLANK )
 
-	PORT_START	/* 16bit */
-	PORT_DIPNAME( 0x0001, 0x0001, "1" )
-	PORT_DIPSETTING(      0x0001, DEF_STR( Off ) )
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x0002, 0x0002, DEF_STR( Unknown ) )
-	PORT_DIPSETTING(      0x0002, DEF_STR( Off ) )
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x0004, 0x0004, DEF_STR( Unknown ) )
-	PORT_DIPSETTING(      0x0004, DEF_STR( Off ) )
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x0008, 0x0000, DEF_STR( Unknown ) )
-	PORT_DIPSETTING(      0x0008, DEF_STR( Off ) )
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x0010, 0x0010, DEF_STR( Unknown ) )
-	PORT_DIPSETTING(      0x0010, DEF_STR( Off ) )
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x0020, 0x0020, DEF_STR( Unknown ) )
-	PORT_DIPSETTING(      0x0020, DEF_STR( Off ) )
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x0040, 0x0040, DEF_STR( Unknown ) )
+	PORT_START_TAG("DSW")
+	PORT_DIPNAME( 0x0007, 0x0007, DEF_STR( Coin_A ) )
+	PORT_DIPSETTING(      0x0000, DEF_STR( 3C_1C ) )
+	PORT_DIPSETTING(      0x0001, DEF_STR( 2C_1C ) )
+	PORT_DIPSETTING(      0x0007, DEF_STR( 1C_1C ) )
+	PORT_DIPSETTING(      0x0006, DEF_STR( 1C_2C ) )
+	PORT_DIPSETTING(      0x0005, DEF_STR( 1C_3C ) )
+	PORT_DIPSETTING(      0x0004, DEF_STR( 1C_4C ) )
+	PORT_DIPSETTING(      0x0003, DEF_STR( 1C_5C ) )
+	PORT_DIPSETTING(      0x0002, DEF_STR( 1C_6C ) )
+	PORT_DIPNAME( 0x0038, 0x0038, DEF_STR( Coin_B ) ) 
+	PORT_DIPSETTING(      0x0000, DEF_STR( 3C_1C ) )
+	PORT_DIPSETTING(      0x0008, DEF_STR( 2C_1C ) )
+	PORT_DIPSETTING(      0x0038, DEF_STR( 1C_1C ) )
+	PORT_DIPSETTING(      0x0030, DEF_STR( 1C_2C ) )
+	PORT_DIPSETTING(      0x0028, DEF_STR( 1C_3C ) )
+	PORT_DIPSETTING(      0x0020, DEF_STR( 1C_4C ) )
+	PORT_DIPSETTING(      0x0018, DEF_STR( 1C_5C ) )
+	PORT_DIPSETTING(      0x0010, DEF_STR( 1C_6C ) )
+	PORT_DIPNAME( 0x0040, 0x0040, DEF_STR( Flip_Screen ) ) 
 	PORT_DIPSETTING(      0x0040, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x0080, 0x0080, DEF_STR( Unknown ) )
-	PORT_DIPSETTING(      0x0080, DEF_STR( Off ) )
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x0100, 0x0100, DEF_STR( Unknown ) )
-	PORT_DIPSETTING(      0x0100, DEF_STR( Off ) )
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x0200, 0x0200, DEF_STR( Unknown ) )
-	PORT_DIPSETTING(      0x0200, DEF_STR( Off ) )
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x0400, 0x0400, DEF_STR( Unknown ) )
-	PORT_DIPSETTING(      0x0400, DEF_STR( Off ) )
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x0800, 0x0800, DEF_STR( Unknown ) )
-	PORT_DIPSETTING(      0x0800, DEF_STR( Off ) )
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x1000, 0x1000, DEF_STR( Unknown ) )
-	PORT_DIPSETTING(      0x1000, DEF_STR( Off ) )
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x2000, 0x2000, DEF_STR( Unknown ) )
-	PORT_DIPSETTING(      0x2000, DEF_STR( Off ) )
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x4000, 0x4000, DEF_STR( Unknown ) )
-	PORT_DIPSETTING(      0x4000, DEF_STR( Off ) )
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x8000, 0x8000, DEF_STR( Unknown ) )
+	PORT_DIPNAME( 0x0080, 0x0080, "Territory" )  /*Manual says "don't change this" */
+	PORT_DIPSETTING(      0x0080, "Japan" )
+	PORT_DIPSETTING(      0x0000, "Korea" )
+	/* 16bit - These values are for Dip Switch #2 */
+	PORT_DIPNAME( 0x0300, 0x0300, DEF_STR( Lives ) )
+	PORT_DIPSETTING(      0x0100, "1" )
+	PORT_DIPSETTING(      0x0000, "2" )
+	PORT_DIPSETTING(      0x0300, "3" )
+	PORT_DIPSETTING(      0x0200, "5" )
+	PORT_DIPNAME( 0x0c00, 0x0c00, "Difficulty" )
+	PORT_DIPSETTING(      0x0800, "Easy" ) 
+	PORT_DIPSETTING(      0x0c00, "Normal" )
+	PORT_DIPSETTING(      0x0400, "Hard" )
+	PORT_DIPSETTING(      0x0000, "Hardest" ) 
+	PORT_DIPNAME( 0x3000, 0x3000, DEF_STR( Bonus_Life ) ) 
+	PORT_DIPSETTING(      0x2000, "Every 100,000" )
+	PORT_DIPSETTING(      0x3000, "Every 150,000" )
+	PORT_DIPSETTING(      0x1000, "Every 300,000" )
+	PORT_DIPSETTING(      0x0000, "250,000 Only" )
+	PORT_DIPNAME( 0x4000, 0x4000, "Allow_Continue" )
+	PORT_DIPSETTING(      0x0000, DEF_STR( Off ) )
+	PORT_DIPSETTING(      0x4000, DEF_STR( On ) )
+	PORT_DIPNAME( 0x8000, 0x0000, DEF_STR( Demo_Sounds ) ) 
 	PORT_DIPSETTING(      0x8000, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
 
-	PORT_START	/* 16bit */
+	PORT_START_TAG("UNK")
 	PORT_DIPNAME( 0x0001, 0x0001, "2" )
 	PORT_DIPSETTING(      0x0001, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
@@ -519,32 +650,35 @@ INPUT_PORTS_START( dblewing )
 	PORT_DIPNAME( 0x8000, 0x8000, DEF_STR( Unknown ) )
 	PORT_DIPSETTING(      0x8000, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
-
-
 INPUT_PORTS_END
 
-static void sound_irq(int irq)
+static void sound_irq_dblewing( int state)
 {
-//  cpunum_set_input_line(1,0,irq ? ASSERT_LINE : CLEAR_LINE);
-//  printf("sound irq\n");
+	/* bit 0 of dblewing_sound_irq specifies IRQ from sound chip */
+	if (state)
+		dblewing_sound_irq |= 0x01;
+	else
+		dblewing_sound_irq &= ~0x01;
+	cpunum_set_input_line(1,0, (dblewing_sound_irq != 0) ? ASSERT_LINE : CLEAR_LINE);
 }
 
 static struct YM2151interface ym2151_interface =
 {
-	sound_irq
+	sound_irq_dblewing
 };
 
 
 static MACHINE_DRIVER_START( dblewing )
 	/* basic machine hardware */
-	MDRV_CPU_ADD(M68000, 14000000)	/* DE102 */
+	MDRV_CPU_ADD(M68000, 14000000)	/* DECO102 */
 	MDRV_CPU_PROGRAM_MAP(dblewing_map,0)
 	MDRV_CPU_VBLANK_INT(irq6_line_hold,1)
 
 	MDRV_CPU_ADD(Z80, 4000000)
 	MDRV_CPU_PROGRAM_MAP(sound_map,0)
+	MDRV_CPU_IO_MAP(dblewing_io_sound,0)
 
-
+        MDRV_INTERLEAVE(100)	/* high interleave to ensure proper synchronization of CPUs */
 	MDRV_FRAMES_PER_SECOND(58)
 	MDRV_VBLANK_DURATION(DEFAULT_REAL_60HZ_VBLANK_DURATION)
 
@@ -563,7 +697,7 @@ static MACHINE_DRIVER_START( dblewing )
 
 	MDRV_SOUND_ADD(YM2151, 32220000/9)
 	MDRV_SOUND_CONFIG(ym2151_interface)
-	MDRV_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.45)
+	MDRV_SOUND_ROUTE(ALL_OUTPUTS, "mono", 0.40)
 
 	MDRV_SOUND_ADD(OKIM6295, 32220000/32/132)
 	MDRV_SOUND_CONFIG(okim6295_interface_region_1)
@@ -614,13 +748,18 @@ MBE-02.8H    [5a6d3ac5]
 */
 
 ROM_START( dblewing )
-	ROM_REGION( 0x80000, REGION_CPU1, 0 ) /* DE102 code (encrypted) */
+	ROM_REGION( 0x80000, REGION_CPU1, 0 ) /* DECO102 code (encrypted) */
 	ROM_LOAD16_BYTE( "kp_00-.3d",    0x000001, 0x040000, CRC(547dc83e) SHA1(f6f96bd4338d366f06df718093f035afabc073d1) )
 	ROM_LOAD16_BYTE( "kp_01-.5d",    0x000000, 0x040000, CRC(7a210c33) SHA1(ced89140af6d6a1bc0ffb7728afca428ed007165) )
 
-	ROM_REGION( 0x10000, REGION_CPU2, 0 ) // sound cpu?
-	ROM_LOAD( "kp_02-.10h",    0x00000, 0x10000, CRC(def035fa) SHA1(fd50314e5c94c25df109ee52c0ce701b0ff2140c) )
+	ROM_REGION( 0x18000, REGION_CPU2, 0 ) /* sound cpu*/
+	ROM_LOAD( "kp_02-.10h",    0x00000, 0x08000, CRC(def035fa) SHA1(fd50314e5c94c25df109ee52c0ce701b0ff2140c) )
+        ROM_CONTINUE(              0x10000, 0x08000 )
 
+        ROM_REGION( 0x10000, REGION_SOUND2, 0 ) /* sound data*/
+	ROM_COPY( REGION_CPU2,  0x00000, 0x00000, 0x8000 )
+	ROM_COPY( REGION_CPU2,  0x10000, 0x08000, 0x8000 )
+	
 	ROM_REGION( 0x100000, REGION_GFX1, ROMREGION_DISPOSE )
 	ROM_LOAD( "mbe-02.8h",    0x00000, 0x100000, CRC(5a6d3ac5) SHA1(738bb833e2c5d929ac75fe4e69ee0af88197d8a6) )
 
@@ -630,7 +769,12 @@ ROM_START( dblewing )
 
 	ROM_REGION( 0x80000, REGION_SOUND1, 0 ) /* Oki samples */
 	ROM_LOAD( "kp_03-.16h",    0x00000, 0x20000, CRC(5d7f930d) SHA1(ad23aa804ea3ccbd7630ade9b53fc3ea2718a6ec) )
+	ROM_RELOAD(                0x20000, 0x20000 )
+	ROM_RELOAD(                0x40000, 0x20000 )
+	ROM_RELOAD(                0x60000, 0x20000 )
 ROM_END
+
+extern void deco102_decrypt(int region, int address_xor, int data_select_xor, int opcode_select_xor);
 
 static DRIVER_INIT( dblewing )
 {
@@ -639,4 +783,4 @@ static DRIVER_INIT( dblewing )
 }
 
 
-GAME( 1993, dblewing, 0,        dblewing, dblewing,  dblewing,  ROT90,"Mitchell", "Double Wings", GAME_UNEMULATED_PROTECTION | GAME_NO_SOUND|GAME_NOT_WORKING)
+GAME(1993, dblewing, 0,  dblewing, dblewing, dblewing,  ROT90, "Mitchell", "Double Wings", GAME_UNEMULATED_PROTECTION | GAME_IMPERFECT_SOUND )


### PR DESCRIPTION
0.129u3: Angelo Salese improved the sound in Double Wings by appling the same handling of Night Slashers (they are actually similar if not same memory map).

0.128u4: Angelo Salese fixed several protection issues with Double Wings, improved video and sound. Added 'Territory' dipswitch.

21st November 2008: Angelo Salese - Looking at Double Wings protection, first of all to fix the protection jump vectors in it. Protection works in a easier way than expected, to say in the simplest words I can use it's a "fan type jump vectors" (i.e. only a few possible results are expected).

0.126u4: Fabio Priuli added DIP locations to Double Wings.

0.106u3: Brian Troha, Guru and Yasuhiro Ogawa updated dipswitches in Double Wings. These dips are read using the protection, thus they don't currently have the stated effect on the game as the protection is not implemented right now. Also the Original PCB showed the title screen in English, and the current implementation shows it in Korean(?), so it is likely there is a Language dip/jumper setting. Added 'Coin A/B', 'Flip Screen', 'Lives', 'Difficulty', 'Bonus Life', 'Allow Continue' and 'Demo Sounds'.