### PR TITLE
Data East's Secret Agent / Sly Spy add RNG protection emulation

### DIFF
--- a/src/machine/dec0.c
+++ b/src/machine/dec0.c
@@ -112,6 +112,12 @@ READ16_HANDLER( slyspy_protection_r )
 		case 2: 	return 0x13;
 		case 4:		return 0;
 		case 6:		return 0x2;
+
+		/* sly spy uses this port as RNG, for now let's do same thing as bootleg (i.e. reads 0x306028)
+		   chances are that it actually ties to the main CPU xtal instead.
+		   (reads at 6958 6696)
+		*/
+		case 0xc:	return dec0_ram[0x2028/2] >> 8;
 	}
 
 	logerror("%04x, Unknown protection read at 30c000 %d\n",activecpu_get_pc(),offset);


### PR DESCRIPTION
Emulated Sly Spy RNG device at $31c00d. This makes gameplay behave very differently than before, game extensively uses this port to mix up stuff especially with the bosses. [Angelo Salese]