### PR TITLE
Re-add Tetris The Absolute The Grandmaster 2

### DIFF
--- a/src/drivers/psikyosh.c
+++ b/src/drivers/psikyosh.c
@@ -373,7 +373,10 @@ static NVRAM_HANDLER(93C56)
  				if (use_factory_eeprom==EEPROM_GNBARICH) /* Might as well do Gnbarich as well, otherwise the highscore is incorrect */
  					memcpy(eeprom_data+0xf0, gnbarich_eeprom, 0x10);
 
-				EEPROM_set_data(eeprom_data,0x100);
+				if (use_factory_eeprom==EEPROM_TGM2) /* load a default eeprom for TGM2 / TGM2+ as it requires more data initalized */
+					memcpy(eeprom_data, memory_region(REGION_USER1), 0x100);
+					
+				    EEPROM_set_data(eeprom_data,0x100);
 			}
 		}
 	}
@@ -816,10 +819,10 @@ INPUT_PORTS_START( mjgtaste ) /* This will need the Mahjong inputs */
 	PORT_COIN( 0 )
 
 	PORT_START_TAG("IN4")/* jumper pads on the PCB */
-//  PORT_DIPNAME( 0x03, 0x01, DEF_STR( Region ) )
-//  PORT_DIPSETTING(    0x00, DEF_STR( Japan ) )
-//  PORT_DIPSETTING(    0x02, "International Ver A." )
-//  PORT_DIPSETTING(    0x01, "International Ver B." )
+    PORT_DIPNAME( 0x03, 0x01, DEF_STR( Region ) )
+    PORT_DIPSETTING(    0x00, DEF_STR( Japan ) )
+    PORT_DIPSETTING(    0x02, "International Ver A." )
+    PORT_DIPSETTING(    0x01, "International Ver B." )
 INPUT_PORTS_END
 
 
@@ -1064,6 +1067,71 @@ ROM_START( mjgtaste )
 	ROM_LOAD( "snd0.u52", 0x000000, 0x200000, NO_DUMP )
 ROM_END
 
+ROM_START( tgm2 )
+	ROM_REGION( 0x100000,  REGION_CPU1, 0)
+	ROM_LOAD32_WORD_SWAP( "2.u21",   0x000000, 0x080000, CRC(b19f6c31) SHA1(c58346c575db71262aebc3993743cb031c41e4af) )
+	ROM_LOAD32_WORD_SWAP( "1.u22",   0x000002, 0x080000, CRC(c521bf24) SHA1(0ee5b9f74b6b8bcc01b2270c53f30d99e877ed64) )
+
+	ROM_REGION( 0x3000000, REGION_GFX1, ROMTEST_GFX )	/* Sprites */
+	// Lower positions not populated
+	ROM_LOAD32_WORD( "81ts_3l.u6",   0x0c00000, 0x200000, CRC(d77cff9c) SHA1(93ee48c350110ebf9a80cca95c599c90a523147d) )
+	ROM_LOAD32_WORD( "82ts_3h.u14",  0x0c00002, 0x200000, CRC(f012b583) SHA1(907e1c93cbfa6a0285f96c53f5ccb63e313053d7) )
+	ROM_LOAD32_WORD( "83ts_4l.u7",   0x1000000, 0x200000, CRC(078cafc3) SHA1(26e47c8f0aaa461e69e9f40ee61ce4b4cc480776) )
+	ROM_LOAD32_WORD( "84ts_4h.u15",  0x1000002, 0x200000, CRC(1f91446b) SHA1(81b43156c6a0f4e63dcc9e7c1e9dd54bcba38240) )
+	ROM_LOAD32_WORD( "85ts_5l.u8",   0x1400000, 0x200000, CRC(40fbd259) SHA1(6b8cbfc6232e04785fd232158b3f4d56fadb0c7d) )
+	ROM_LOAD32_WORD( "86ts_5h.u16",  0x1400002, 0x200000, CRC(186c935f) SHA1(0cab30c2ec4df3dc35b4c9de63d29bd0bc99afdb) )
+	ROM_LOAD32_WORD( "87ts_6l.u1",   0x1800000, 0x200000, CRC(c17dc48a) SHA1(4399bfc253fb1cd4ef1081d7350c73df3a0f7441) )
+	ROM_LOAD32_WORD( "88ts_6h.u2",   0x1800002, 0x200000, CRC(e4dba5da) SHA1(24db1e19f4df94ba3a22fba59e4fd065921db1c5) )
+	ROM_LOAD32_WORD( "89ts_7l.u19",  0x1c00000, 0x200000, CRC(dab1b2c5) SHA1(114fd7717b97cdfd605ab7e2a354190c41ba4a82) )
+	ROM_LOAD32_WORD( "90ts_7h.u20",  0x1c00002, 0x200000, CRC(aae696b3) SHA1(9ac27365719c1700f647911dc324a0e2aacea172) )
+	ROM_LOAD32_WORD( "91ts_8l.u28",  0x2000000, 0x200000, CRC(e953ace1) SHA1(c6cdfd807a7a84b86378c3585aeb7c0cb066f8a1) )
+	ROM_LOAD32_WORD( "92ts_8h.u29",  0x2000002, 0x200000, CRC(9da3b976) SHA1(ce1e4eb93760749200ede45703412868ca29a5e7) )
+	ROM_LOAD32_WORD( "93ts_9l.u41",  0x2400000, 0x200000, CRC(233087fe) SHA1(c4adb307ce11ef558fd23b299ce7f458de581446) )
+	ROM_LOAD32_WORD( "94ts_9h.u42",  0x2400002, 0x200000, CRC(9da831c7) SHA1(42698697aa85df088745b2d37ec89b01adce700f) )
+	ROM_LOAD32_WORD( "95ts_10l.u58", 0x2800000, 0x200000, CRC(303a5240) SHA1(5816d1922e85bc27a2a13cdd183d9e67c7ddb2e1) )
+	ROM_LOAD32_WORD( "96ts_10h.u59", 0x2800002, 0x200000, CRC(2240ebf6) SHA1(b61f93a18dd9d94fb57d95745d4df2e41a0371ff) )
+
+	ROM_REGION( 0x800000, REGION_SOUND1, 0 ) /* Samples */
+	ROM_LOAD( "97ts_snd.u52", 0x000000, 0x400000, CRC(9155eca6) SHA1(f0b4f68462d8a465c39815d3b7fd9818788132ae) )
+
+	ROM_REGION( 0x100, REGION_USER1, 0 ) /* Default Eeprom (contains scores etc.) */
+	// might need byteswapping to reprogram actual chip
+	ROM_LOAD( "tgm2.default.nv", 0x000, 0x100, CRC(50e2348c) SHA1(d17d2739c97a1d93a95dcc9f11feb1f6f228729e) )
+ROM_END
+
+
+ROM_START( tgm2p )
+	ROM_REGION( 0x100000,  REGION_CPU1, 0)
+	ROM_LOAD32_WORD_SWAP( "2b.u21",   0x000000, 0x080000, CRC(38bc626c) SHA1(783e8413b11f1fa08d331b09ef4ed63f62b87ead) )
+	ROM_LOAD32_WORD_SWAP( "1b.u22",   0x000002, 0x080000, CRC(7599fb19) SHA1(3f7e81756470c173cc17a7e7dee91437571fd0c3) )
+
+	ROM_REGION( 0x3000000, REGION_GFX1, ROMTEST_GFX )	/* Sprites */
+	// Lower positions not populated
+	ROM_LOAD32_WORD( "81ts_3l.u6",   0x0c00000, 0x200000, CRC(d77cff9c) SHA1(93ee48c350110ebf9a80cca95c599c90a523147d) )
+	ROM_LOAD32_WORD( "82ts_3h.u14",  0x0c00002, 0x200000, CRC(f012b583) SHA1(907e1c93cbfa6a0285f96c53f5ccb63e313053d7) )
+	ROM_LOAD32_WORD( "83ts_4l.u7",   0x1000000, 0x200000, CRC(078cafc3) SHA1(26e47c8f0aaa461e69e9f40ee61ce4b4cc480776) )
+	ROM_LOAD32_WORD( "84ts_4h.u15",  0x1000002, 0x200000, CRC(1f91446b) SHA1(81b43156c6a0f4e63dcc9e7c1e9dd54bcba38240) )
+	ROM_LOAD32_WORD( "85ts_5l.u8",   0x1400000, 0x200000, CRC(40fbd259) SHA1(6b8cbfc6232e04785fd232158b3f4d56fadb0c7d) )
+	ROM_LOAD32_WORD( "86ts_5h.u16",  0x1400002, 0x200000, CRC(186c935f) SHA1(0cab30c2ec4df3dc35b4c9de63d29bd0bc99afdb) )
+	ROM_LOAD32_WORD( "87ts_6l.u1",   0x1800000, 0x200000, CRC(c17dc48a) SHA1(4399bfc253fb1cd4ef1081d7350c73df3a0f7441) )
+	ROM_LOAD32_WORD( "88ts_6h.u2",   0x1800002, 0x200000, CRC(e4dba5da) SHA1(24db1e19f4df94ba3a22fba59e4fd065921db1c5) )
+	ROM_LOAD32_WORD( "89ts_7l.u19",  0x1c00000, 0x200000, CRC(dab1b2c5) SHA1(114fd7717b97cdfd605ab7e2a354190c41ba4a82) )
+	ROM_LOAD32_WORD( "90ts_7h.u20",  0x1c00002, 0x200000, CRC(aae696b3) SHA1(9ac27365719c1700f647911dc324a0e2aacea172) )
+	ROM_LOAD32_WORD( "91ts_8l.u28",  0x2000000, 0x200000, CRC(e953ace1) SHA1(c6cdfd807a7a84b86378c3585aeb7c0cb066f8a1) )
+	ROM_LOAD32_WORD( "92ts_8h.u29",  0x2000002, 0x200000, CRC(9da3b976) SHA1(ce1e4eb93760749200ede45703412868ca29a5e7) )
+	ROM_LOAD32_WORD( "93ts_9l.u41",  0x2400000, 0x200000, CRC(233087fe) SHA1(c4adb307ce11ef558fd23b299ce7f458de581446) )
+	ROM_LOAD32_WORD( "94ts_9h.u42",  0x2400002, 0x200000, CRC(9da831c7) SHA1(42698697aa85df088745b2d37ec89b01adce700f) )
+	ROM_LOAD32_WORD( "95ts_10l.u58", 0x2800000, 0x200000, CRC(303a5240) SHA1(5816d1922e85bc27a2a13cdd183d9e67c7ddb2e1) )
+	ROM_LOAD32_WORD( "96ts_10h.u59", 0x2800002, 0x200000, CRC(2240ebf6) SHA1(b61f93a18dd9d94fb57d95745d4df2e41a0371ff) )
+
+	ROM_REGION( 0x800000, REGION_SOUND1, 0 ) /* Samples */
+
+	ROM_LOAD( "97ts_snd.u52", 0x000000, 0x400000, CRC(9155eca6) SHA1(f0b4f68462d8a465c39815d3b7fd9818788132ae) )
+
+	ROM_REGION( 0x100, REGION_USER1, 0 ) /* Default Eeprom (contains scores etc.) */
+	// might need byteswapping to reprogram actual chip
+	ROM_LOAD( "tgm2p.default.nv", 0x000, 0x100, CRC(b2328b40) SHA1(e6cda4d6f4e91b9f78d2ca84a5eee6c3bd03fe02) )
+ROM_END
 /* are these right? should i fake the counter return?
    'speedups / idle skipping isn't needed for 'hotgmck, hgkairak'
    as the core catches and skips the idle loops automatically'
@@ -1210,7 +1278,25 @@ static READ32_HANDLER( mjgtaste_speedup_r )
 	return psh_ram[0x006000C/4];
 }
 
+static READ32_HANDLER( tgm2_speedup_r )
+{
+	if (activecpu_get_pc()==0x0602895A) cpu_spinuntil_int(); // startup texts
+	if (activecpu_get_pc()==0x06028EF2) cpu_spinuntil_int(); // attract game
+	if (activecpu_get_pc()==0x06028CAC) cpu_spinuntil_int(); // game
+	
 
+	return psh_ram[0x006000C/4];
+}
+
+static READ32_HANDLER( tgm2p_speedup_r )
+{
+	if (activecpu_get_pc()==0x0602AE5A) cpu_spinuntil_int(); // startup texts
+	if (activecpu_get_pc()==0x0602B3F2) cpu_spinuntil_int(); // attract game
+	if (activecpu_get_pc()==0x0602B1AC) cpu_spinuntil_int(); // game
+	
+
+	return psh_ram[0x006000C/4];
+}
 
 static DRIVER_INIT( soldivid )
 {
@@ -1273,7 +1359,17 @@ static DRIVER_INIT( mjgtaste )
 	/* needs to install mahjong controls too (can select joystick in test mode tho) */
 }
 
+static DRIVER_INIT( tgm2 )
+{
+	memory_install_read32_handler(0, ADDRESS_SPACE_PROGRAM, 0x606000c, 0x606000f, 0, 0, tgm2_speedup_r );
+	use_factory_eeprom=EEPROM_TGM2;
+}
 
+static DRIVER_INIT( tgm2p )
+{
+	memory_install_read32_handler(0, ADDRESS_SPACE_PROGRAM, 0x606000c, 0x606000f, 0, 0, tgm2p_speedup_r );
+	use_factory_eeprom=EEPROM_TGM2;
+}
 /*     YEAR  NAME      PARENT    MACHINE    INPUT     INIT      MONITOR COMPANY   FULLNAME FLAGS */
 
 /* ps3-v1 */
@@ -1288,5 +1384,7 @@ GAME( 1999, s1945iii, 0,        psikyo5,     s1945iii, s1945iii, ROT270, "Psikyo
 
 /* ps5v2 */
 GAME( 2000, dragnblz, 0,        psikyo5,     dragnblz, dragnblz, ROT270, "Psikyo", "Dragon Blaze", 0 )
+GAME( 2000, tgm2,     0,      	psikyo5_240, mjgtaste, tgm2,     ROT0,   "Arika"   "Tetris the Absolute The Grand Master 2", 0 )
+GAME( 2000, tgm2p,    tgm2, 	psikyo5_240, mjgtaste, tgm2p,    ROT0,   "Arika",  "Tetris the Absolute The Grand Master 2 Plus", 0 )
 GAME( 2001, gnbarich, 0,        psikyo5,     gnbarich, gnbarich, ROT270, "Psikyo", "Gunbarich", 0 )
 GAME( 2002, mjgtaste, 0,        psikyo5,     mjgtaste, mjgtaste, ROT0,   "Psikyo", "Mahjong G-Taste", GAME_NOT_WORKING )


### PR DESCRIPTION
0.129: Re-added 'Tetris the Absolute The Grand Master 2' (Arika 2000) and clone 'Tetris the Absolute The Grand Master 2 Plus'.

0.99u5: This game was removed from MAME.

0.99u4: Guru added 'Tetris the Absolute The Grand Master 2' (Arika 2000) and clone 'Tetris the Absolute The Grand Master 2 Plus'.

22nd August 2005: Guru - I've just finished to dumped the tricky surface mounted roms of tgm2_plus. There were 7 used on the PCB and each one had to be removed from the PCB and mounted onto this adapter, dumped, then removed and remounted onto the PCB. Luckily I'm a patient man.

17th June 2005: Guru - Tetris GM 2 and GM 2+ arrived from Japan.

4th April 2005: Dumping Project - Our Japanese contact bought with the help of massive targeted monetary infusions from two of the world's biggest Tetris fans, Arika's 'Tetris the Grand Master 2' and 'Tetris the Grand Master 2 Plus' !! (Those two buys were horribly, hideously complicated and expensive to arrange, but now what are arguably the best arcade versions of Tetris ever made will, hopefully, soon be dumped).