### PR TITLE
update v60

### DIFF
--- a/src/cpu/v60/v60.c
+++ b/src/cpu/v60/v60.c
@@ -2,7 +2,7 @@
 // Undiscover the beast!
 // Main hacking and coding by Farfetch'd
 // Portability fixes by Richter Belmont
-
+#include <math.h>
 #include "debugger.h"
 #include "v60.h"
 


### PR DESCRIPTION
This fixes vr not working on arm due to differences to unsigned to float due to it being undefined behavior as well as fixing the round behavior that was missing. Back ported from latest mame master.   