### PR TITLE
Fix slowdown in Taito's Fighting Hawk

### DIFF
--- a/src/drivers/taito_l.c
+++ b/src/drivers/taito_l.c
@@ -2296,7 +2296,7 @@ static struct YM2203interface ym2203_interface_single =
 static MACHINE_DRIVER_START( fhawk )
 
 	/* basic machine hardware */
-	MDRV_CPU_ADD_TAG("cpu1", Z80, 6000000)	/* ? xtal is 13.33056 */
+	MDRV_CPU_ADD_TAG("cpu1", Z80, 6665280)	/* ? xtal is 13.33056 */
 	MDRV_CPU_PROGRAM_MAP(fhawk_readmem,fhawk_writemem)
 	MDRV_CPU_VBLANK_INT(vbl_interrupt,3)
 
@@ -2304,9 +2304,9 @@ static MACHINE_DRIVER_START( fhawk )
 	/* audio CPU */
 	MDRV_CPU_PROGRAM_MAP(fhawk_3_readmem,fhawk_3_writemem)
 
-	MDRV_CPU_ADD_TAG("cpu2", Z80, 6000000)	/* ? xtal is 13.33056 */
+	MDRV_CPU_ADD_TAG("cpu2", Z80, 4000000)	/* ? xtal is 13.33056 */
 	MDRV_CPU_PROGRAM_MAP(fhawk_2_readmem,fhawk_2_writemem)
-	MDRV_CPU_VBLANK_INT(irq0_line_hold,1)
+	MDRV_CPU_VBLANK_INT(irq0_line_hold,3)
 
 	MDRV_FRAMES_PER_SECOND(60)
 	MDRV_VBLANK_DURATION(DEFAULT_60HZ_VBLANK_DURATION)


### PR DESCRIPTION
0.122u2: Changed Z80 CPU1 clock speed to 6665280 Hz, Z80 CPU3 to 4MHz and irq0_line_hold to 3, this fixes the slowdown problems.